### PR TITLE
"previously defined algorithms" -> "previous standards-track algorith…

### DIFF
--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -388,7 +388,8 @@ congestion control algorithms.
 In contexts where differing congestion control
 algorithms are used, it is important to understand whether
 the proposed congestion control algorithm could result in more
-harm than previously defined algorithms to flows sharing a common bottleneck.
+harm than previous standards-track algorithms (e.g. {{!RFC5681}},
+{{!RFC9002}}, {{!RFC9438}}) to flows sharing a common bottleneck.
 The measure of harm is not restricted to the equality
 of capacity, but ought also to consider metrics such as the
 introduced latency, or an increase in packet loss. An evaluation must


### PR DESCRIPTION
…ms..."

AFAICT the goal is to consider harm induced relative to the harm induced by Reno/CUBIC. There may be other experimental algorithms that become "defined", which are not intended as a yardstick by which to measure harm.