### PR TITLE
Restore end of PR #57

### DIFF
--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -1,4 +1,4 @@
----
+y---
 title: "Specifying New Congestion Control Algorithms"
 abbrev: "New CC Algorithms"
 docname: draft-ietf-ccwg-rfc5033bis-latest
@@ -480,7 +480,7 @@ a proposed congestion control algorithm
 can analyze and simulate their interaction with those algorithms. To the
 extent they are not, experiments can be conducted where possible.
 
-Real-time flows can directed into distinct
+Real-time flows can be directed into distinct
 queues via Differentiated Services Code Points (DSCP) or other mechanisms,
 which can substantially reduce the interplay with other traffic. However, a proposal
 targeting general Internet use can not assume this is always the case.

--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -1,4 +1,4 @@
-y---
+---
 title: "Specifying New Congestion Control Algorithms"
 abbrev: "New CC Algorithms"
 docname: draft-ietf-ccwg-rfc5033bis-latest

--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -480,7 +480,7 @@ a proposed congestion control algorithm
 can analyze and simulate their interaction with those algorithms. To the
 extent they are not, experiments can be conducted where possible.
 
-Real-time flows can directed into distinct 
+Real-time flows can directed into distinct
 queues via Differentiated Services Code Points (DSCP) or other mechanisms,
 which can substantially reduce the interplay with other traffic. However, a proposal
 targeting general Internet use can not assume this is always the case.

--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -480,10 +480,10 @@ a proposed congestion control algorithm
 can analyze and simulate their interaction with those algorithms. To the
 extent they are not, experiments can be conducted where possible.
 
-Note that in many deployments, real-time flows are directed into distinct
+Real-time flows can directed into distinct 
 queues via Differentiated Services Code Points (DSCP) or other mechanisms,
-which substantially reduces the interplay with other traffic. However, a proposal
-targeting general Internet use
+which can substantially reduce the interplay with other traffic. However, a proposal
+targeting general Internet use can not assume this is always the case.
 
 ### Short and Long Flows
 


### PR DESCRIPTION
Fixed an editorial problem resulting in removing the end of the sentence, which went on to say that you can't assume DSCP, etc. 
Also changed /many deployments/ to simply say this happens without saying it is often.