### PR TITLE
Minor update to fix NiTs from Shepherd Review

### DIFF
--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -539,7 +539,7 @@ path, the proposal MUST consider the effect of traffic passing through a tunnel,
 where routers may not be aware of the flow.
 
 The design of tunnels and similar encapsulations might need to consider nested
-congestion control interactions. For example, when ECN is used by an
+congestion control interactions. For example, when ECN is used by both an
 IP and lower layer technology {{ECN-Encaps}}.
 
 ## Wired Paths

--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -49,6 +49,8 @@ informative:
 
   BBRv1-draft: I-D.cardwell-iccrg-bbr-congestion-control-00
 
+  ECN-Encaps: I-D.ietf-tsvwg-ecn-encap-guidelines-21
+
   HRX08:
     title: "CUBIC: a new TCP-friendly high-speed TCP variant"
     seriesinfo: ACM SIGOPS Operating Systems Review, vol. 42, no. 5, pp. 64-74
@@ -158,7 +160,7 @@ CUBIC was documented in a research publication in 2007 {{HRX08}}, and was then
 adopted as the default congestion control algorithm for the TCP implementation
 in Linux. It was already used in a significant fraction of TCP connections over
 the Internet before being documented in an Informational Internet-Draft in
-2015, published as an Informational RFC in 2017 {{?RFC8312}} and then as a
+2015, published as an Informational RFC in 2017 as {{?RFC8312}} and then as a
 Proposed Standard in 2023 {{?RFC9438}}.
 
 At the time of writing, BBR is being developed as an internal research project
@@ -327,7 +329,7 @@ this requirement is crucial to protect the network in times of extreme
 (persistent) congestion.
 
 If full backoff is used, this test does not require that the mechanism must be
-identical to that of TCP ({{?RFC2988}}, {{!RFC8961}}). For example, this does
+identical to that of TCP ({{?RFC6298}}, {{!RFC8961}}). For example, this does
 not preclude full backoff mechanisms that would give flows with different round-
 trip times comparable capacity during backoff.
 
@@ -528,6 +530,10 @@ disciplines.
 When a proposed congestion control algorithm relies on explicit signals from the
 path, the proposal MUST consider the effect of traffic passing through a tunnel,
 where routers may not be aware of the flow.
+
+The design of tunnels and similar encapsulations might need to consider nested 
+congestion control interactions. For example, when ECN is used by an
+IP and lower layer technology {{ECN-Encaps}}.
 
 ## Wired Paths
 

--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -272,6 +272,13 @@ documenting deployed congestion control algorithms that cannot be changed by
 IETF or IRTF review are invited to publish as an Informational RFC via the
 Independent Stream Editor (ISE).
 
+# Specification of Requirements
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
+
 # Specifying Algorithms for Use in Controlled Environments {#controlled-environments}
 
 Algorithms can be designed for general Internet deployment or for use in

--- a/draft-ietf-ccwg-rfc5033bis.md
+++ b/draft-ietf-ccwg-rfc5033bis.md
@@ -531,7 +531,7 @@ When a proposed congestion control algorithm relies on explicit signals from the
 path, the proposal MUST consider the effect of traffic passing through a tunnel,
 where routers may not be aware of the flow.
 
-The design of tunnels and similar encapsulations might need to consider nested 
+The design of tunnels and similar encapsulations might need to consider nested
 congestion control interactions. For example, when ECN is used by an
 IP and lower layer technology {{ECN-Encaps}}.
 


### PR DESCRIPTION
A new PR will addreess these issues, when rev'ed as an ID.

1. -- Obsolete informational reference (is this intentional?): RFC 2988 (Obsoleted by RFC 6298)

mea culpa for not spotting - we ought to replace by the later RFC.

2.  -- Obsolete informational reference (is this intentional?): RFC 8312 (Obsoleted by RFC 9438)

That was intentional. The text of the PR has been updated to say this.

3. We can add a note that tunnels, and similar encaps need to consider nested congestion control interactions:

The design of tunnels and similar encapsulations might need to consider nested congestion control interactions. For example, when ECN is used by an IP and lower layer technology {{ECN-encaps}}.